### PR TITLE
weather summary days headers with normal user-configurable dates instead of today, tomoroow etc

### DIFF
--- a/panel-plugin/weather-config.c
+++ b/panel-plugin/weather-config.c
@@ -485,6 +485,19 @@ text_timezone_changed(const GtkWidget *entry,
     schedule_delayed_data_update(dialog);
 }
 
+static void
+text_dayformat_changed(const GtkWidget *entry,
+                      gpointer user_data)
+{
+    xfceweather_dialog *dialog = (xfceweather_dialog *) user_data;
+
+    if (dialog->pd->dayformat)
+        g_free(dialog->pd->dayformat);
+    dialog->pd->dayformat = g_strdup(gtk_entry_get_text(GTK_ENTRY(entry)));
+    schedule_delayed_data_update(dialog);
+}
+
+
 
 static void
 create_location_page(xfceweather_dialog *dialog)
@@ -531,6 +544,19 @@ create_location_page(xfceweather_dialog *dialog)
                            dialog->pd->timezone);
     else
         gtk_entry_set_text(GTK_ENTRY(dialog->text_timezone), "");
+        
+        
+        /* dayformat */
+    dialog->text_dayformat = GTK_WIDGET (gtk_builder_get_object (GTK_BUILDER (dialog->builder), "text_dayformat"));
+    gtk_entry_set_max_length(GTK_ENTRY(dialog->text_dayformat),
+                             LOC_NAME_MAX_LEN);
+    if (dialog->pd->dayformat)
+        gtk_entry_set_text(GTK_ENTRY(dialog->text_dayformat),
+                           dialog->pd->dayformat);
+    else
+        gtk_entry_set_text(GTK_ENTRY(dialog->text_dayformat), "");
+        
+        
 
     /* set up the altitude spin box and unit label (meters/feet) */
     setup_altitude(dialog);
@@ -1085,6 +1111,11 @@ create_appearance_page(xfceweather_dialog *dialog)
     dialog->check_round_values = GTK_WIDGET (gtk_builder_get_object (GTK_BUILDER (dialog->builder), "check_round_values"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(dialog->check_round_values),
                                  dialog->pd->round);
+                                 
+
+
+
+
 }
 
 
@@ -1650,6 +1681,10 @@ setup_notebook_signals(xfceweather_dialog *dialog)
                      G_CALLBACK(spin_alt_value_changed), dialog);
     g_signal_connect(GTK_EDITABLE(dialog->text_timezone), "changed",
                      G_CALLBACK(text_timezone_changed), dialog);
+	
+	g_signal_connect(GTK_EDITABLE(dialog->text_dayformat), "changed",
+                     G_CALLBACK(text_dayformat_changed), dialog);
+
 
     /* units page */
     g_signal_connect(dialog->combo_unit_temperature, "changed",
@@ -1681,7 +1716,11 @@ setup_notebook_signals(xfceweather_dialog *dialog)
                      G_CALLBACK(spin_forecast_days_value_changed), dialog);
     g_signal_connect(dialog->check_round_values, "toggled",
                      G_CALLBACK(check_round_values_toggled), dialog);
-
+                     
+    g_signal_connect(GTK_EDITABLE(dialog->text_dayformat), "changed",
+                     G_CALLBACK(text_dayformat_changed), dialog);
+                     
+    
     /* scrollbox page */
     g_signal_connect(dialog->check_scrollbox_show, "state-set",
                      G_CALLBACK(check_scrollbox_show_toggled), dialog);

--- a/panel-plugin/weather-config.h
+++ b/panel-plugin/weather-config.h
@@ -41,6 +41,7 @@ typedef struct {
     GtkWidget *label_alt_unit;
     GtkWidget *text_timezone;
     GtkWidget *update_spinner;
+    GtkWidget *text_dayformat;
 
     /* units page */
     GtkWidget *combo_unit_temperature;
@@ -59,6 +60,7 @@ typedef struct {
     GtkWidget *spin_forecast_days;
     GtkWidget *check_round_values;
     GtkWidget *check_single_row;
+
 
     /* scrollbox page */
     GtkWidget *check_scrollbox_show;

--- a/panel-plugin/weather-config.ui
+++ b/panel-plugin/weather-config.ui
@@ -212,6 +212,23 @@
                     <property name="top_attach">5</property>
                   </packing>
                 </child>
+                
+                <child>
+                  <object class="GtkLabel" id="label555">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">_Dayformat:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">text_dayformat</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                
+                
                 <child>
                   <object class="GtkBox" id="box2">
                     <property name="visible">True</property>
@@ -339,6 +356,17 @@ Leave this field empty to use the timezone set by your system. Invalid entries w
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="text_dayformat">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_markup" translatable="yes">Format date for days in the summary view. Use C string format, for example %d %b, %a. More help about date format you can find in the help for the clock plugin.</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -895,6 +923,8 @@ Leave this field empty to use the timezone set by your system. Invalid entries w
                     <property name="width">2</property>
                   </packing>
                 </child>
+                
+                
               </object>
               <packing>
                 <property name="position">2</property>

--- a/panel-plugin/weather-summary.c
+++ b/panel-plugin/weather-summary.c
@@ -626,15 +626,22 @@ create_summary_tab(plugin_data *data)
 
 
 static gchar *
-get_dayname(gint day)
+get_dayname(gint day, gchar * dayformat)
 {
     struct tm fcday_tm;
     time_t now_t = time(NULL), fcday_t;
     gint weekday;
+    gchar *value;
 
     fcday_tm = *localtime(&now_t);
     fcday_t = time_calc_day(fcday_tm, day);
     weekday = localtime(&fcday_t)->tm_wday;
+    //value = format_date(fcday_t, "%d %b, %a", TRUE);
+    if (dayformat==NULL) {dayformat = "%d %b, %a";}
+    value = format_date(fcday_t, dayformat, TRUE);
+    
+    return value;
+    
     switch (day) {
     case 0:
         return g_strdup_printf(_("Today"));
@@ -985,7 +992,7 @@ make_forecast(plugin_data *data)
 
     for (i = 0; i < data->forecast_days; i++) {
         /* forecast day headers */
-        dayname = get_dayname(i);
+        dayname = get_dayname(i,data->dayformat);
         if (data->forecast_layout == FC_LAYOUT_CALENDAR)
             ebox = add_forecast_header(dayname, 0.0, "darkbg");
         else

--- a/panel-plugin/weather.h
+++ b/panel-plugin/weather.h
@@ -40,6 +40,7 @@
 #define SETTING_LONGITUDE     "/location/longitude"
 #define SETTING_MSL           "/msl"
 #define SETTING_TIMEZONE      "/timezone"
+#define SETTING_DAYFORMAT     "/dayformat"
 #define SETTING_OFFSET        "/offset"
 #define SETTING_GEONAMES      "/geonames-username"
 #define SETTING_CACHE_MAX_AGE "/cache-max-age"
@@ -165,6 +166,7 @@ typedef struct {
     gchar *lon;
     gint msl;
     gchar *timezone;
+    gchar *dayformat;
     gchar *offset;
     gchar *timezone_initial;
     gint cache_file_max_age;


### PR DESCRIPTION
Hi!
Added possibility to use normal dates on weather summary screen. For me not seeing actual calendar day number is rather annoying and confusing so I've added this to it.
![зображення](https://github.com/xfce-mirror/xfce4-weather-plugin/assets/229040/6072e88d-c3e6-45bf-80e8-c4f4acdfa037)
